### PR TITLE
Change file.relativeDir to file.dir for compatibility with transformers

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -50,7 +50,7 @@ exports.sourceNodes = async (
                 fileAbsolutePath: file.url,
                 relativePath: file.path,
                 base: path.basename(file.path),
-                relativeDirectory: path.dirname(file.path),
+                dir: path.dirname(file.path),
                 url: file.url,
                 type: file.type,
                 mime: mimeType,


### PR DESCRIPTION
This PR is in reference to issue #19, in which I describe incompatibility of this plugin with `gatsby-transformer-yaml` and `gatsby-transformer-json`.